### PR TITLE
feat: remove Full Site Editor from menu bar

### DIFF
--- a/includes/actions/general.php
+++ b/includes/actions/general.php
@@ -17,6 +17,15 @@ if ( carbon_get_theme_option( 'wowcore_disable_file_edit' ) ) {
 }
 
 /**
+ * Disable Full Site Editing
+ */
+if ( carbon_get_theme_option( 'wowcore_disable_fse' ) ) {
+	add_action( 'admin_menu', function () {
+		remove_submenu_page( 'themes.php', 'site-editor.php' );
+	} );
+}
+
+/**
  * Disable comments
  */
 if ( carbon_get_theme_option( 'wowcore_disable_comments' ) ) {

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -11,6 +11,8 @@ add_action( 'carbon_fields_register_fields', function () {
 		     ->set_default_value( true ),
 		Field::make( 'checkbox', 'wowcore_disable_file_edit', __( 'Disable Theme & Plugin Editors' ) )
 		     ->set_default_value( true ),
+		Field::make( 'checkbox', 'wowcore_disable_fse', __( 'Disable Full Site Editing' ) )
+		     ->set_default_value( true ),
 		Field::make( 'checkbox', 'wowcore_disable_default_post_type', __( 'Disable default Post type' ) )
 			 ->set_default_value( true ),
 		Field::make( 'checkbox', 'wowcore_disable_comments', __( 'Disable comments' ) )


### PR DESCRIPTION
This PR adds an option to disable the menu item Appearance -> Editor (beta)

[There is a plugin](https://github.com/janw-me/disable-full-site-editing) that does this better, but the code is not as straightforward as I would've liked to port it here, so this is only what I managed to do. 

This code has no redirection from `wp-admin/site-editor.php` to `admin_url()` because I couldn't get the usual snippet to work:

```php
add_action( 'template_redirect', function () {
	global $pagenow;

	if ( $pagenow === 'site-editor.php' ) {
		wp_redirect( admin_url() );
		exit;
	}
} );
```

Any ideas are welcomed :) 